### PR TITLE
Add index v2 specs-go and schema

### DIFF
--- a/schema/image-index-schema.json
+++ b/schema/image-index-schema.json
@@ -1,0 +1,97 @@
+{
+  "description": "OpenContainer Image Index Specification",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://opencontainers.org/schema/image/index",
+  "type": "object",
+  "properties": {
+    "schemaVersion": {
+      "description": "This field specifies the image index schema version as an integer",
+      "id": "https://opencontainers.org/schema/image/index/schemaVersion",
+      "type": "integer",
+      "minimum": 2,
+      "maximum": 2
+    },
+    "mediaType": {
+      "description": "the mediatype of the referenced object",
+      "$ref": "defs-descriptor.json#/definitions/mediaType"
+    },
+    "config": {
+      "$ref": "https://opencontainers.org/schema/descriptor"
+    },
+    "manifests": {
+      "type": "array",
+      "items": {
+        "id": "https://opencontainers.org/schema/image/manifestDescriptor",
+        "type": "object",
+        "required": [
+          "mediaType",
+          "size",
+          "digest"
+        ],
+        "properties": {
+          "mediaType": {
+            "description": "the mediatype of the referenced object",
+            "$ref": "defs-descriptor.json#/definitions/mediaType"
+          },
+          "size": {
+            "description": "the size in bytes of the referenced object",
+            "$ref": "defs.json#/definitions/int64"
+          },
+          "digest": {
+            "description": "the cryptographic checksum digest of the object, in the pattern '<algorithm>:<encoded>'",
+            "$ref": "defs-descriptor.json#/definitions/digest"
+          },
+          "urls": {
+            "description": "a list of urls from which this object may be downloaded",
+            "$ref": "defs-descriptor.json#/definitions/urls"
+          },
+          "platform": {
+            "id": "https://opencontainers.org/schema/image/platform",
+            "type": "object",
+            "required": [
+              "architecture",
+              "os"
+            ],
+            "properties": {
+              "architecture": {
+                "id": "https://opencontainers.org/schema/image/platform/architecture",
+                "type": "string"
+              },
+              "os": {
+                "id": "https://opencontainers.org/schema/image/platform/os",
+                "type": "string"
+              },
+              "os.version": {
+                "id": "https://opencontainers.org/schema/image/platform/os.version",
+                "type": "string"
+              },
+              "os.features": {
+                "id": "https://opencontainers.org/schema/image/platform/os.features",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "variant": {
+                "type": "string"
+              }
+            }
+          },
+          "annotations": {
+            "id": "https://opencontainers.org/schema/image/descriptor/annotations",
+            "$ref": "defs-descriptor.json#/definitions/annotations"
+          }
+        }
+      }
+    },
+    "annotations": {
+      "id": "https://opencontainers.org/schema/image/index/annotations",
+      "$ref": "defs-descriptor.json#/definitions/annotations"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "config",
+    "manifests"
+  ]
+}

--- a/specs-go/v2/descriptor.go
+++ b/specs-go/v2/descriptor.go
@@ -1,0 +1,64 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import digest "github.com/opencontainers/go-digest"
+
+// Descriptor describes the disposition of targeted content.
+// This structure provides `application/vnd.oci.descriptor.v1+json` mediatype
+// when marshalled to JSON.
+type Descriptor struct {
+	// MediaType is the media type of the object this schema refers to.
+	MediaType string `json:"mediaType,omitempty"`
+
+	// Digest is the digest of the targeted content.
+	Digest digest.Digest `json:"digest"`
+
+	// Size specifies the size in bytes of the blob.
+	Size int64 `json:"size"`
+
+	// URLs specifies a list of URLs from which this object MAY be downloaded
+	URLs []string `json:"urls,omitempty"`
+
+	// Annotations contains arbitrary metadata relating to the targeted content.
+	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// Platform describes the platform which the image in the manifest runs on.
+	//
+	// This should only be used when referring to a manifest.
+	Platform *Platform `json:"platform,omitempty"`
+}
+
+// Platform describes the platform which the image in the manifest runs on.
+type Platform struct {
+	// Architecture field specifies the CPU architecture, for example
+	// `amd64` or `ppc64`.
+	Architecture string `json:"architecture"`
+
+	// OS specifies the operating system, for example `linux` or `windows`.
+	OS string `json:"os"`
+
+	// OSVersion is an optional field specifying the operating system
+	// version, for example on Windows `10.0.14393.1066`.
+	OSVersion string `json:"os.version,omitempty"`
+
+	// OSFeatures is an optional field specifying an array of strings,
+	// each listing a required OS feature (for example on Windows `win32k`).
+	OSFeatures []string `json:"os.features,omitempty"`
+
+	// Variant is an optional field specifying a variant of the CPU, for
+	// example `v7` to specify ARMv7 when architecture is `arm`.
+	Variant string `json:"variant,omitempty"`
+}

--- a/specs-go/v2/index.go
+++ b/specs-go/v2/index.go
@@ -1,0 +1,31 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+// Index references manifests for various platforms.
+// This structure provides `application/vnd.oci.image.index.v2+json` mediatype when marshalled to JSON.
+type Index struct {
+	// MediaType is the media type of the object this schema refers to.
+	MediaType string `json:"mediaType,omitempty"`
+
+	// Config references the index configuration.
+	Config Descriptor `json:"config,omitempty"`
+
+	// Manifests references platform specific manifests.
+	Manifests []Descriptor `json:"manifests"`
+
+	// Annotations contains arbitrary metadata for the image index.
+	Annotations map[string]string `json:"annotations,omitempty"`
+}

--- a/specs-go/v2/mediatype.go
+++ b/specs-go/v2/mediatype.go
@@ -1,0 +1,20 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+const (
+	// MediaTypeImageIndex specifies the media type for an image index.
+	MediaTypeImageIndex = "application/vnd.oci.image.index.v2+json"
+)


### PR DESCRIPTION
This PR copies the files required to add manifest referrer metadata support (https://github.com/notaryproject/distribution/pull/2) from https://github.com/opencontainers/image-spec, with some additional modifications:
- Copied `schema/image-index-schema.json` and added a new property, `config`
- Copied `specs-go/v2/descriptor.json`
- Copied `specs-go/v2/index.go` and added new property, `Config`
- Defined a new media type, `application/vnd.oci.image.index.v2+json`